### PR TITLE
Check ability to allocate packet buffer when calling ready()

### DIFF
--- a/platform/genode/block_client.h
+++ b/platform/genode/block_client.h
@@ -30,7 +30,7 @@ namespace Block
                     const char *device = nullptr,
                     void *callback = nullptr);
             void finalize();
-            bool ready();
+            bool ready(Request Req);
             void enqueue_read(Request req);
             void enqueue_write(
                     Request req,

--- a/platform/genode/cai-block-client.adb
+++ b/platform/genode/cai-block-client.adb
@@ -101,10 +101,10 @@ package body Cai.Block.Client is
       return R;
    end Convert_Request;
 
-   function Ready (C : Client_Session) return Boolean
+   function Ready (C : Client_Session; R : Request) return Boolean
    is
    begin
-      return Cxx.Block.Client.Ready (C.Instance) = 1;
+      return Cxx.Block.Client.Ready (C.Instance, Convert_Request (R)) = 1;
    end Ready;
 
    procedure Enqueue_Read (C : Client_Session; R : Request)

--- a/platform/genode/cxx-block-client.ads
+++ b/platform/genode/cxx-block-client.ads
@@ -36,8 +36,8 @@ is
    procedure Finalize (This : Class)
    with Global => null, Import, Convention => CPP, External_Name => "_ZN3Cai5Block6Client8finalizeEv";
 
-   function Ready (This : Class) return Cxx.Bool
-   with Global => null, Import, Convention => CPP, External_Name => "_ZN3Cai5Block6Client5readyEv";
+   function Ready (This : Class; Req : Cxx.Block.Request.Class) return Cxx.Bool
+   with Global => null, Import, Convention => CPP, External_Name => "_ZN3Cai5Block6Client5readyENS0_7RequestE";
 
    procedure Enqueue_Read (This : Class; Req : Cxx.Block.Request.Class)
    with Global => null, Import, Convention => CPP, External_Name => "_ZN3Cai5Block6Client12enqueue_readENS0_7RequestE";

--- a/src/cai-block-client.ads
+++ b/src/cai-block-client.ads
@@ -17,24 +17,24 @@ is
 
    procedure Finalize (C : in out Client_Session);
 
-   function Ready (C : Client_Session) return Boolean with
+   function Ready (C : Client_Session; R : Request) return Boolean with
       Volatile_Function;
 
    procedure Enqueue_Read (C : Client_Session; R : Request) with
       Pre => R.Kind = Read
              and R.Status = Raw
-             and Ready (C);
+             and Ready (C, R);
 
    procedure Enqueue_Write (C : Client_Session; R : Request; B : Buffer) with
       Pre => R.Kind = Write
              and R.Status = Raw
              and B'Length = R.Length * Block_Size (C)
-             and Ready (C);
+             and Ready (C, R);
 
    procedure Enqueue_Sync (C : Client_Session; R : Request) with
       Pre => R.Kind = Sync
              and R.Status = Raw
-             and Ready (C);
+             and Ready (C, R);
 
    procedure Submit (C : Client_Session);
 


### PR DESCRIPTION
To manage the preallocated packet the `Packet_allocator` is used. It provides `reallocate`, `free` and `take`. `reallocate` can always be used and allocates a packet of the given size. If a packet is already allocated it will either be used if it has the same size or freed otherwise and a new one is allocated. `free` releases the packet and replaces the packet descriptor with an empty one. `take` takes the currently allocated packet and returns it. It sets the internal packet descriptor to an empty one without freeing it. Before each call of `take` `reallocate`has to be called at least once.