### PR TITLE
Duration image and block client parameter modes

### DIFF
--- a/platform/genode/cai-block-client.adb
+++ b/platform/genode/cai-block-client.adb
@@ -107,13 +107,13 @@ package body Cai.Block.Client is
       return Cxx.Block.Client.Ready (C.Instance, Convert_Request (R)) = 1;
    end Ready;
 
-   procedure Enqueue_Read (C : Client_Session; R : Request)
+   procedure Enqueue_Read (C : in out Client_Session; R : Request)
    is
    begin
       Cxx.Block.Client.Enqueue_Read (C.Instance, Convert_Request (R));
    end Enqueue_Read;
 
-   procedure Enqueue_Write (C : Client_Session; R : Request; B : Buffer)
+   procedure Enqueue_Write (C : in out Client_Session; R : Request; B : Buffer)
    is
       subtype Local_Buffer is Buffer (1 .. B'Length);
       subtype Local_U8_Array is Cxx.Genode.Uint8_T_Array (1 .. B'Length);
@@ -126,13 +126,13 @@ package body Cai.Block.Client is
          Data);
    end Enqueue_Write;
 
-   procedure Enqueue_Sync (C : Client_Session; R : Request)
+   procedure Enqueue_Sync (C : in out Client_Session; R : Request)
    is
    begin
       Cxx.Block.Client.Enqueue_Sync (C.Instance, Convert_Request (R));
    end Enqueue_Sync;
 
-   procedure Submit (C : Client_Session)
+   procedure Submit (C : in out Client_Session)
    is
    begin
       Cxx.Block.Client.Submit (C.Instance);
@@ -144,7 +144,7 @@ package body Cai.Block.Client is
       return Convert_Request (Cxx.Block.Client.Next (C.Instance));
    end Next;
 
-   procedure Read (C : Client_Session; R : Request; B : out Buffer)
+   procedure Read (C : in out Client_Session; R : Request; B : out Buffer)
    is
       subtype Local_Buffer is Buffer (1 .. B'Length);
       subtype Local_U8_Array is Cxx.Genode.Uint8_T_Array (1 .. B'Length);
@@ -158,7 +158,7 @@ package body Cai.Block.Client is
       B := Convert_Buffer (Data);
    end Read;
 
-   procedure Release (C : Client_Session; R : in out Request)
+   procedure Release (C : in out Client_Session; R : in out Request)
    is
    begin
       Cxx.Block.Client.Release (C.Instance, Convert_Request (R));

--- a/platform/genode/cai-log-client.adb
+++ b/platform/genode/cai-log-client.adb
@@ -49,7 +49,7 @@ package body Cai.Log.Client is
    procedure Info (C : in out Client_Session; Msg : String; Newline : Boolean := True)
    is
       C_Msg : String := Msg
-                        & (if Newline then Nl & Terminator else Terminator & Terminator);
+                        & (if Newline then Nl & Terminator else (1 => Terminator));
    begin
       Cxx.Log.Client.Write (C.Instance, C_Msg'Address);
    end Info;
@@ -57,7 +57,7 @@ package body Cai.Log.Client is
    procedure Warning (C : in out Client_Session; Msg : String; Newline : Boolean := True)
    is
       C_Msg : String := Blue & "Warning: " & Msg & Reset
-                        & (if Newline then Nl & Terminator else Terminator & Terminator);
+                        & (if Newline then Nl & Terminator else (1 => Terminator));
    begin
       Cxx.Log.Client.Write (C.Instance, C_Msg'Address);
    end Warning;
@@ -65,7 +65,7 @@ package body Cai.Log.Client is
    procedure Error (C : in out Client_Session; Msg : String; Newline : Boolean := True)
    is
       C_Msg : String := Red & "Error: " & Msg & Reset
-                        & (if Newline then Nl & Terminator else Terminator & Terminator);
+                        & (if Newline then Nl & Terminator else (1 => Terminator));
    begin
       Cxx.Log.Client.Write (C.Instance, C_Msg'Address);
    end Error;

--- a/platform/genode/cai-log-client.adb
+++ b/platform/genode/cai-log-client.adb
@@ -44,24 +44,28 @@ package body Cai.Log.Client is
    Red : constant String := Character'Val (8#33#) & "[31m";
    Reset : constant String := Character'Val (8#33#) & "[0m";
    Terminator : constant Character := Character'Val (0);
+   Nl : constant Character := Character'Val (10);
 
-   procedure Info (C : in out Client_Session; Msg : String)
+   procedure Info (C : in out Client_Session; Msg : String; Newline : Boolean := True)
    is
-      C_Msg : String := Msg & Terminator;
+      C_Msg : String := Msg
+                        & (if Newline then Nl & Terminator else Terminator & Terminator);
    begin
       Cxx.Log.Client.Write (C.Instance, C_Msg'Address);
    end Info;
 
-   procedure Warning (C : in out Client_Session; Msg : String)
+   procedure Warning (C : in out Client_Session; Msg : String; Newline : Boolean := True)
    is
-      C_Msg : String := Blue & "Warning: " & Msg & Reset & Terminator;
+      C_Msg : String := Blue & "Warning: " & Msg & Reset
+                        & (if Newline then Nl & Terminator else Terminator & Terminator);
    begin
       Cxx.Log.Client.Write (C.Instance, C_Msg'Address);
    end Warning;
 
-   procedure Error (C : in out Client_Session; Msg : String)
+   procedure Error (C : in out Client_Session; Msg : String; Newline : Boolean := True)
    is
-      C_Msg : String := Red & "Error: " & Msg & Reset & Terminator;
+      C_Msg : String := Red & "Error: " & Msg & Reset
+                        & (if Newline then Nl & Terminator else Terminator & Terminator);
    begin
       Cxx.Log.Client.Write (C.Instance, C_Msg'Address);
    end Error;

--- a/src/cai-block-client.ads
+++ b/src/cai-block-client.ads
@@ -20,23 +20,23 @@ is
    function Ready (C : Client_Session; R : Request) return Boolean with
       Volatile_Function;
 
-   procedure Enqueue_Read (C : Client_Session; R : Request) with
+   procedure Enqueue_Read (C : in out Client_Session; R : Request) with
       Pre => R.Kind = Read
              and R.Status = Raw
              and Ready (C, R);
 
-   procedure Enqueue_Write (C : Client_Session; R : Request; B : Buffer) with
+   procedure Enqueue_Write (C : in out Client_Session; R : Request; B : Buffer) with
       Pre => R.Kind = Write
              and R.Status = Raw
              and B'Length = R.Length * Block_Size (C)
              and Ready (C, R);
 
-   procedure Enqueue_Sync (C : Client_Session; R : Request) with
+   procedure Enqueue_Sync (C : in out Client_Session; R : Request) with
       Pre => R.Kind = Sync
              and R.Status = Raw
              and Ready (C, R);
 
-   procedure Submit (C : Client_Session);
+   procedure Submit (C : in out Client_Session);
 
    function Next (C : Client_Session) return Request with
       Volatile_Function,
@@ -48,12 +48,12 @@ is
                else
                   True);
 
-   procedure Read (C : Client_Session; R : Request; B : out Buffer) with
+   procedure Read (C : in out Client_Session; R : Request; B : out Buffer) with
       Pre => R.Kind = Read
              and R.Status = Ok
              and B'Length >= R.Length * Block_Size (C);
 
-   procedure Release (C : Client_Session; R : in out Request) with
+   procedure Release (C : in out Client_Session; R : in out Request) with
       Pre => R.Kind /= None
              and (R.Status = Ok or R.Status = Error);
 

--- a/src/cai-log-client.ads
+++ b/src/cai-log-client.ads
@@ -17,15 +17,15 @@ is
       Pre => Initialized (C),
       Post => Maximal_Message_Length'Result > 78;
 
-   procedure Info (C : in out Client_Session; Msg : String) with
+   procedure Info (C : in out Client_Session; Msg : String; Newline : Boolean := True) with
       Pre => Initialized (C)
              and Msg'Length <= Maximal_Message_Length (C);
 
-   procedure Warning (C : in out Client_Session; Msg : String) with
+   procedure Warning (C : in out Client_Session; Msg : String; Newline : Boolean := True) with
       Pre => Initialized (C)
              and Msg'Length <= Maximal_Message_Length (C);
 
-   procedure Error (C : in out Client_Session; Msg : String) with
+   procedure Error (C : in out Client_Session; Msg : String; Newline : Boolean := True) with
       Pre => Initialized (C)
              and Msg'Length <= Maximal_Message_Length (C);
 

--- a/src/cai-log.adb
+++ b/src/cai-log.adb
@@ -71,4 +71,18 @@ is
       end return;
    end Image;
 
+   function Image (V : Duration) return String
+   is
+      Seconds : constant Integer := Integer (V - 0.5);
+      Frac : Integer := Integer ((V - Duration (Seconds)) * 1000000);
+      Simg : constant String := Image (Seconds);
+      Fimg : String (1 .. 6) := (others => '0');
+   begin
+      for I in reverse Fimg'Range loop
+         Fimg (I) := Character'Val (48 + abs(Frac rem 10));
+         Frac := Frac / 10;
+      end loop;
+      return Simg & "." & Fimg;
+   end Image;
+
 end Cai.Log;

--- a/src/cai-log.ads
+++ b/src/cai-log.ads
@@ -15,6 +15,8 @@ is
       Post => Image'Result'Length <= 5;
    function Image (V : Unsigned) return String with
       Post => Image'Result'Length <= 16;
+   function Image (V : Duration) return String with
+      Post => Image'Result'Length <= 27;
 
    type Client_Session is limited private;
 


### PR DESCRIPTION
Adds a `Cai.Log.Image` function for the `Duration` type. Fixes the parameter mode of some block client procedures to represent the actual semantics.