### PR TITLE
Configurable buffer size

### DIFF
--- a/platform/genode/block_client.cc
+++ b/platform/genode/block_client.cc
@@ -120,7 +120,7 @@ class Packet_allocator
         {
             if(size != _alloc_packet.size()){
                 free(device);
-                _alloc_packet = blk(device)->dma_alloc_packet(size);
+                _alloc_packet = blk(device)->tx()->alloc_packet(size, 0);
             }
         }
 

--- a/platform/genode/block_client.h
+++ b/platform/genode/block_client.h
@@ -15,6 +15,7 @@ namespace Block
         private:
             Genode::uint64_t _block_count;
             Genode::uint64_t _block_size;
+            Genode::uint64_t _buffer_size;
             void *_device; //Block_session in block_client.cc
             void *_callback; //procedure Event (S : Instance);
 
@@ -28,7 +29,8 @@ namespace Block
             bool initialized();
             void initialize(
                     const char *device = nullptr,
-                    void *callback = nullptr);
+                    void *callback = nullptr,
+                    Genode::uint64_t buffer_size = 0);
             void finalize();
             bool ready(Request Req);
             void enqueue_read(Request req);
@@ -45,6 +47,7 @@ namespace Block
             bool writable();
             Genode::uint64_t block_count();
             Genode::uint64_t block_size();
+            Genode::uint64_t maximal_transfer_size();
     };
 }
 

--- a/platform/genode/cai-block-client.adb
+++ b/platform/genode/cai-block-client.adb
@@ -26,14 +26,14 @@ package body Cai.Block.Client is
       return Cxx.Block.Client.Initialized (C.Instance) = 1;
    end Initialized;
 
-   procedure Initialize (C : in out Client_Session; Path : String)
+   procedure Initialize (C : in out Client_Session; Path : String; Buffer_Size : Unsigned_Long := 0)
    is
       C_Path : constant String := Path & Character'Val(0);
       subtype C_Path_String is String (1 .. C_Path'Length);
       subtype C_String is Cxx.Char_Array (1 .. C_Path'Length);
       function To_C_String is new Ada.Unchecked_Conversion (C_Path_String, C_String);
    begin
-      Cxx.Block.Client.Initialize (C.Instance, To_C_String (C_Path), Event'Address);
+      Cxx.Block.Client.Initialize (C.Instance, To_C_String (C_Path), Event'Address, Cxx.Genode.Uint64_T (Buffer_Size));
    end Initialize;
 
    procedure Finalize (C : in out Client_Session)
@@ -184,9 +184,8 @@ package body Cai.Block.Client is
 
    function Maximal_Transfer_Size (C : Client_Session) return Unsigned_Long
    is
-      pragma Unreferenced (C);
    begin
-      return 1024 ** 2;
+      return Unsigned_Long (Cxx.Block.Client.Maximal_Transfer_Size (C.Instance));
    end Maximal_Transfer_Size;
 
 end Cai.Block.Client;

--- a/platform/genode/cxx-block-client.ads
+++ b/platform/genode/cxx-block-client.ads
@@ -11,6 +11,7 @@ is
    limited record
       Private_X_Block_Count : Private_Uint64_T;
       Private_X_Block_Size : Private_Uint64_T;
+      Private_X_Buffer_Size : Private_Uint64_T;
       Private_X_Device : Private_Void;
       Private_X_Callback : Private_Void;
    end record
@@ -30,8 +31,8 @@ is
    function Initialized (This : Class) return Cxx.Bool
    with Global => null, Import, Convention => CPP, External_Name => "_ZN3Cai5Block6Client11initializedEv";
 
-   procedure Initialize (This : Class; Device : Cxx.Char_Array; Callback : Cxx.Void_Address)
-   with Global => null, Import, Convention => CPP, External_Name => "_ZN3Cai5Block6Client10initializeEPKcPv";
+   procedure Initialize (This : Class; Device : Cxx.Char_Array; Callback : Cxx.Void_Address; Buffer_Size : Cxx.Genode.Uint64_T)
+   with Global => null, Import, Convention => CPP, External_Name => "_ZN3Cai5Block6Client10initializeEPKcPvy";
 
    procedure Finalize (This : Class)
    with Global => null, Import, Convention => CPP, External_Name => "_ZN3Cai5Block6Client8finalizeEv";
@@ -68,6 +69,9 @@ is
 
    function Block_Size (This : Class) return Cxx.Genode.Uint64_T
    with Global => null, Import, Convention => CPP, External_Name => "_ZN3Cai5Block6Client10block_sizeEv";
+
+   function Maximal_Transfer_Size (This : Class) return Cxx.Genode.Uint64_T
+   with Global => null, Import, Convention => CPP, External_Name => "_ZN3Cai5Block6Client21maximal_transfer_sizeEv";
 
 private
    pragma SPARK_Mode (Off);

--- a/src/cai-block-client.ads
+++ b/src/cai-block-client.ads
@@ -13,7 +13,7 @@ is
 
    function Initialized (C : Client_Session) return Boolean;
 
-   procedure Initialize (C : in out Client_Session; Path : String);
+   procedure Initialize (C : in out Client_Session; Path : String; Buffer_Size : Unsigned_Long := 0);
 
    procedure Finalize (C : in out Client_Session);
 


### PR DESCRIPTION
The buffer size of a client can now be configured via the initialize procedure. The maximal transfer size procedure returns the actual usable buffer size (which is taken from the used allocator) rounded down to the next multiple of the block size.