### PR TITLE
Client interface refinement

### DIFF
--- a/platform/genode/block_client.cc
+++ b/platform/genode/block_client.cc
@@ -163,9 +163,9 @@ bool Cai::Block::Client::ready(Cai::Block::Request req)
                        || req.kind == Cai::Block::TRIM);
 }
 
-bool Cai::Block::Client::supported(Cai::Block::Request req)
+bool Cai::Block::Client::supported(Cai::Block::Kind kind)
 {
-    return req.kind == Cai::Block::READ || req.kind == Cai::Block::WRITE;
+    return kind == Cai::Block::READ || kind == Cai::Block::WRITE;
 }
 
 void Cai::Block::Client::enqueue_read(Cai::Block::Request req)

--- a/platform/genode/block_client.cc
+++ b/platform/genode/block_client.cc
@@ -259,7 +259,5 @@ Genode::uint64_t Cai::Block::Client::maximal_transfer_size()
 
 void Cai::Block::Client::callback()
 {
-    if(_callback){
-        Call(_callback);
-    }
+    Call(_callback);
 }

--- a/platform/genode/block_client.h
+++ b/platform/genode/block_client.h
@@ -34,7 +34,7 @@ namespace Block
                     Genode::uint64_t buffer_size = 0);
             void finalize();
             bool ready(Request req);
-            bool supported(Request req);
+            bool supported(Kind req);
             void enqueue_read(Request req);
             void enqueue_write(
                     Request req,

--- a/platform/genode/block_client.h
+++ b/platform/genode/block_client.h
@@ -17,7 +17,8 @@ namespace Block
             Genode::uint64_t _block_size;
             Genode::uint64_t _buffer_size;
             void *_device; //Block_session in block_client.cc
-            void *_callback; //procedure Event (S : Instance);
+            void *_callback; //procedure Event;
+            void *_write; //procedure Write (Instance, Block_size, Start, Length, Data)
 
         protected:
             void callback();
@@ -31,16 +32,12 @@ namespace Block
                     void *env,
                     const char *device = nullptr,
                     void *callback = nullptr,
+                    void *write = nullptr,
                     Genode::uint64_t buffer_size = 0);
             void finalize();
             bool ready(Request req);
             bool supported(Kind req);
-            void enqueue_read(Request req);
-            void enqueue_write(
-                    Request req,
-                    Genode::uint8_t *data);
-            void enqueue_sync(Request req);
-            void enqueue_trim(Request req);
+            void enqueue(Request req);
             void submit();
             void read(
                     Request req,

--- a/platform/genode/block_client.h
+++ b/platform/genode/block_client.h
@@ -18,7 +18,7 @@ namespace Block
             Genode::uint64_t _buffer_size;
             void *_device; //Block_session in block_client.cc
             void *_callback; //procedure Event;
-            void *_write; //procedure Write (Instance, Block_size, Start, Length, Data)
+            void *_rw; //procedure Crw (Instance, Kind, Block_size, Start, Length, Data)
 
         protected:
             void callback();
@@ -32,16 +32,14 @@ namespace Block
                     void *env,
                     const char *device = nullptr,
                     void *callback = nullptr,
-                    void *write = nullptr,
+                    void *rw = nullptr,
                     Genode::uint64_t buffer_size = 0);
             void finalize();
             bool ready(Request req);
             bool supported(Kind req);
             void enqueue(Request req);
             void submit();
-            void read(
-                    Request req,
-                    Genode::uint8_t *data);
+            void read(Request req);
             Request next();
             void release(Request req);
             bool writable();

--- a/platform/genode/cai-block-client.adb
+++ b/platform/genode/cai-block-client.adb
@@ -115,10 +115,15 @@ is
    end Ready;
 
    function Supported (C : Client_Session;
-                       R : Request) return Boolean
+                       R : Request_Kind) return Boolean
    is
    begin
-      return Cxx.Block.Client.Supported (C.Instance, Client_Util.Convert_Request (R)) = Cxx.Bool'Val (1);
+      return Cxx.Block.Client.Supported (C.Instance, (case R is
+                                                      when None  => Cxx.Block.None,
+                                                      when Read  => Cxx.Block.Read,
+                                                      when Write => Cxx.Block.Write,
+                                                      when Sync  => Cxx.Block.Sync,
+                                                      when Trim  => Cxx.Block.Trim)) = Cxx.Bool'Val (1);
    end Supported;
 
    procedure Enqueue_Read (C : in out Client_Session;

--- a/platform/genode/cxx-block-client.ads
+++ b/platform/genode/cxx-block-client.ads
@@ -16,6 +16,7 @@ is
       Private_X_Buffer_Size : Private_Uint64_T;
       Private_X_Device      : Private_Void;
       Private_X_Callback    : Private_Void;
+      Private_X_Write       : Private_Void;
    end record
    with Import, Convention => CPP;
 
@@ -43,11 +44,12 @@ is
                          Cap         : Cai.Types.Capability;
                          Device      : Cxx.Char_Array;
                          Callback    : Cxx.Void_Address;
+                         Write       : Cxx.Void_Address;
                          Buffer_Size : Cxx.Genode.Uint64_T) with
       Global        => null,
       Import,
       Convention    => CPP,
-      External_Name => "_ZN3Cai5Block6Client10initializeEPvPKcS2_y";
+      External_Name => "_ZN3Cai5Block6Client10initializeEPvPKcS2_S2_y";
 
    procedure Finalize (This : Class) with
       Global        => null,
@@ -69,34 +71,12 @@ is
       Convention    => CPP,
       External_Name => "_ZN3Cai5Block6Client9supportedENS0_4KindE";
 
-   procedure Enqueue_Read (This : Class;
-                           Req  : Cxx.Block.Request.Class) with
+   procedure Enqueue (This : Class;
+                      Req  : Cxx.Block.Request.Class) with
       Global        => null,
       Import,
       Convention    => CPP,
-      External_Name => "_ZN3Cai5Block6Client12enqueue_readENS0_7RequestE";
-
-   procedure Enqueue_Write (This :        Class;
-                            Req  :        Cxx.Block.Request.Class;
-                            Data : in out Cxx.Genode.Uint8_T_Array) with
-      Global        => null,
-      Import,
-      Convention    => CPP,
-      External_Name => "_ZN3Cai5Block6Client13enqueue_writeENS0_7RequestEPh";
-
-   procedure Enqueue_Sync (This : Class;
-                           Req  : Cxx.Block.Request.Class) with
-      Global        => null,
-      Import,
-      Convention    => CPP,
-      External_Name => "_ZN3Cai5Block6Client12enqueue_syncENS0_7RequestE";
-
-   procedure Enqueue_Trim (This : Class;
-                           Req  : Cxx.Block.Request.Class) with
-      Global        => null,
-      Import,
-      Convention    => CPP,
-      External_Name => "_ZN3Cai5Block6Client12enqueue_trimENS0_7RequestE";
+      External_Name => "_ZN3Cai5Block6Client7enqueueENS0_7RequestE";
 
    procedure Submit (This : Class) with
       Global        => null,

--- a/platform/genode/cxx-block-client.ads
+++ b/platform/genode/cxx-block-client.ads
@@ -63,11 +63,11 @@ is
       External_Name => "_ZN3Cai5Block6Client5readyENS0_7RequestE";
 
    function Supported (This : Class;
-                       Req  : Cxx.Block.Request.Class) return Cxx.Bool with
+                       Req  : Cxx.Block.Kind) return Cxx.Bool with
       Global        => null,
       Import,
       Convention    => CPP,
-      External_Name => "_ZN3Cai5Block6Client9supportedENS0_7RequestE";
+      External_Name => "_ZN3Cai5Block6Client9supportedENS0_4KindE";
 
    procedure Enqueue_Read (This : Class;
                            Req  : Cxx.Block.Request.Class) with

--- a/platform/genode/cxx-block-client.ads
+++ b/platform/genode/cxx-block-client.ads
@@ -91,12 +91,11 @@ is
       External_Name => "_ZN3Cai5Block6Client4nextEv";
 
    procedure Read (This :        Class;
-                   Req  :        Cxx.Block.Request.Class;
-                   Data : in out Cxx.Genode.Uint8_T_Array) with
+                   Req  :        Cxx.Block.Request.Class) with
       Global        => null,
       Import,
       Convention    => CPP,
-      External_Name => "_ZN3Cai5Block6Client4readENS0_7RequestEPh";
+      External_Name => "_ZN3Cai5Block6Client4readENS0_7RequestE";
 
    procedure Release (This : Class;
                       Req  : Cxx.Block.Request.Class) with

--- a/platform/genode/cxx-block-client.ads
+++ b/platform/genode/cxx-block-client.ads
@@ -44,7 +44,7 @@ is
                          Cap         : Cai.Types.Capability;
                          Device      : Cxx.Char_Array;
                          Callback    : Cxx.Void_Address;
-                         Write       : Cxx.Void_Address;
+                         Rw          : Cxx.Void_Address;
                          Buffer_Size : Cxx.Genode.Uint64_T) with
       Global        => null,
       Import,

--- a/platform/genode/genode_packet.h
+++ b/platform/genode/genode_packet.h
@@ -81,7 +81,8 @@ inline Block::Request create_genode_block_request(const Cai::Block::Request &req
             Block::Request::Success::FALSE : Block::Request::Success::TRUE,
         req.start,
         *(reinterpret_cast<const Genode::uint64_t *>(&req.uid)),
-        reinterpret_cast<const Genode::uint32_t*>(&req.length)[0]
+        reinterpret_cast<const Genode::uint32_t*>(&req.length)[0],
+        0
     };
     return r;
 }

--- a/platform/posix/block_client.c
+++ b/platform/posix/block_client.c
@@ -11,11 +11,11 @@ void block_client_initialize(block_client_t **client,
                              const char *path,
                              uint64_t buffer_size,
                              void (*event)(void),
-                             void (*write)(block_client_t *, uint64_t, uint64_t, uint64_t, void*))
+                             void (*rw)(block_client_t *, uint32_t, uint64_t, uint64_t, uint64_t, void*))
 {
     *client = malloc(sizeof(block_client_t));
     (*client)->event = event;
-    (*client)->write = write;
+    (*client)->rw = rw;
 }
 
 void block_client_finalize(block_client_t **client)
@@ -39,7 +39,7 @@ void block_client_submit(block_client_t *client)
 void block_client_next(const block_client_t *client, request_t *request)
 { }
 
-void block_client_read(block_client_t *client, const request_t *request, void *data)
+void block_client_read(block_client_t *client, const request_t *request)
 { }
 
 void block_client_release(block_client_t *client, const request_t *request)

--- a/platform/posix/block_client.c
+++ b/platform/posix/block_client.c
@@ -7,10 +7,15 @@ const block_client_t *block_client_get_instance(const block_client_t *client)
     return client;
 }
 
-void block_client_initialize(block_client_t **client, const char *path, uint64_t buffer_size, void (*event)(void))
+void block_client_initialize(block_client_t **client,
+                             const char *path,
+                             uint64_t buffer_size,
+                             void (*event)(void),
+                             void (*write)(block_client_t *, uint64_t, uint64_t, uint64_t, void*))
 {
     *client = malloc(sizeof(block_client_t));
     (*client)->event = event;
+    (*client)->write = write;
 }
 
 void block_client_finalize(block_client_t **client)
@@ -25,16 +30,7 @@ int block_client_ready(const block_client_t *client, const request_t *request)
 int block_client_supported(const block_client_t *client, uint32_t kind)
 { }
 
-void block_client_enqueue_read(block_client_t *client, const request_t *request)
-{ }
-
-void block_client_enqueue_write(block_client_t *client, const request_t *request, const void *buffer)
-{ }
-
-void block_client_enqueue_sync(block_client_t *client, const request_t *request)
-{ }
-
-void block_client_enqueue_trim(block_client_t *client, const request_t *request)
+void block_client_enqueue(block_client_t *client, const request_t *request)
 { }
 
 void block_client_submit(block_client_t *client)

--- a/platform/posix/block_client.c
+++ b/platform/posix/block_client.c
@@ -22,7 +22,7 @@ void block_client_finalize(block_client_t **client)
 int block_client_ready(const block_client_t *client, const request_t *request)
 { }
 
-int block_client_supported(const block_client_t *client, const request_t *request)
+int block_client_supported(const block_client_t *client, uint32_t kind)
 { }
 
 void block_client_enqueue_read(block_client_t *client, const request_t *request)

--- a/platform/posix/block_client.h
+++ b/platform/posix/block_client.h
@@ -5,14 +5,25 @@
 #include <stdint.h>
 #include <block.h>
 
-typedef struct block_client
+typedef struct block_client block_client_t;
+
+struct block_client
 {
     void (*event)(void);
-} block_client_t;
+    void (*write)(block_client_t *client,
+                  uint64_t block_size,
+                  uint64_t start,
+                  uint64_t length,
+                  void *data);
+};
 
 const block_client_t *block_client_get_instance(const block_client_t *client);
 
-void block_client_initialize(block_client_t **client, const char *path, uint64_t buffer_size, void (*event)(void));
+void block_client_initialize(block_client_t **client,
+                             const char *path,
+                             uint64_t buffer_size,
+                             void (*event)(void),
+                             void (*write)(block_client_t *, uint64_t, uint64_t, uint64_t, void*));
 
 void block_client_finalize(block_client_t **client);
 
@@ -20,13 +31,7 @@ int block_client_ready(const block_client_t *client, const request_t *request);
 
 int block_client_supported(const block_client_t *client, uint32_t kind);
 
-void block_client_enqueue_read(block_client_t *client, const request_t *request);
-
-void block_client_enqueue_write(block_client_t *client, const request_t *request, const void *buffer);
-
-void block_client_enqueue_sync(block_client_t *client, const request_t *request);
-
-void block_client_enqueue_trim(block_client_t *client, const request_t *request);
+void block_client_enqueue(block_client_t *client, const request_t *request);
 
 void block_client_submit(block_client_t *client);
 

--- a/platform/posix/block_client.h
+++ b/platform/posix/block_client.h
@@ -18,7 +18,7 @@ void block_client_finalize(block_client_t **client);
 
 int block_client_ready(const block_client_t *client, const request_t *request);
 
-int block_client_supported(const block_client_t *client, const request_t *request);
+int block_client_supported(const block_client_t *client, uint32_t kind);
 
 void block_client_enqueue_read(block_client_t *client, const request_t *request);
 

--- a/platform/posix/block_client.h
+++ b/platform/posix/block_client.h
@@ -10,11 +10,12 @@ typedef struct block_client block_client_t;
 struct block_client
 {
     void (*event)(void);
-    void (*write)(block_client_t *client,
-                  uint64_t block_size,
-                  uint64_t start,
-                  uint64_t length,
-                  void *data);
+    void (*rw)(block_client_t *client,
+               uint32_t kind,
+               uint64_t block_size,
+               uint64_t start,
+               uint64_t length,
+               void *data);
 };
 
 const block_client_t *block_client_get_instance(const block_client_t *client);
@@ -23,7 +24,7 @@ void block_client_initialize(block_client_t **client,
                              const char *path,
                              uint64_t buffer_size,
                              void (*event)(void),
-                             void (*write)(block_client_t *, uint64_t, uint64_t, uint64_t, void*));
+                             void (*rw)(block_client_t *, uint32_t, uint64_t, uint64_t, uint64_t, void*));
 
 void block_client_finalize(block_client_t **client);
 
@@ -37,7 +38,7 @@ void block_client_submit(block_client_t *client);
 
 void block_client_next(const block_client_t *client, request_t *request);
 
-void block_client_read(block_client_t *client, const request_t *request, void *data);
+void block_client_read(block_client_t *client, const request_t *request);
 
 void block_client_release(block_client_t *client, const request_t *request);
 

--- a/platform/posix/cai-block-client.adb
+++ b/platform/posix/cai-block-client.adb
@@ -101,15 +101,19 @@ is
    ---------------
 
    function Supported (C : Client_Session;
-                       R : Request) return Boolean is
+                       R : Request_Kind) return Boolean is
       function C_Supported (T   : System.Address;
-                            Req : System.Address) return Integer with
+                            Req : Standard.C.Block.Request_Kind) return Integer with
          Import,
          Convention    => C,
          External_Name => "block_client_supported";
-      Req : Standard.C.Block.Request := Convert_Request (R);
    begin
-      return C_Supported (C.Instance, Req'Address) = 1;
+      return C_Supported (C.Instance, (case R is
+                                       when None  => Standard.C.Block.None,
+                                       when Read  => Standard.C.Block.Read,
+                                       when Write => Standard.C.Block.Write,
+                                       when Sync  => Standard.C.Block.Sync,
+                                       when Trim  => Standard.C.Block.Trim)) = 1;
    end Supported;
 
    ------------------

--- a/platform/posix/cai-block-client.adb
+++ b/platform/posix/cai-block-client.adb
@@ -48,6 +48,24 @@ is
    -- Initialize --
    ----------------
 
+   procedure C_Write (C : Client_Instance;
+                      B : Size;
+                      S : Id;
+                      L : Count;
+                      D : System.Address);
+
+   procedure C_Write (C : Client_Instance;
+                      B : Size;
+                      S : Id;
+                      L : Count;
+                      D : System.Address)
+   is
+      Data : Buffer (1 .. B * L) with
+         Address => D;
+   begin
+      Write (C, B, S, L, Data);
+   end C_Write;
+
    procedure Initialize (C           : in out Client_Session;
                          Cap         :        Cai.Types.Capability;
                          Path        :        String;
@@ -58,12 +76,13 @@ is
       procedure C_Initialize (T : out System.Address;
                               P : System.Address;
                               B : Byte_Length;
-                              E : System.Address) with
+                              E : System.Address;
+                              W : System.Address) with
          Import,
          Convention    => C,
          External_Name => "block_client_initialize";
    begin
-      C_Initialize (C.Instance, C_Path'Address, Buffer_Size, Event'Address);
+      C_Initialize (C.Instance, C_Path'Address, Buffer_Size, Event'Address, C_Write'Address);
    end Initialize;
 
    --------------
@@ -120,70 +139,18 @@ is
    -- Enqueue_Read --
    ------------------
 
-   procedure Enqueue_Read (C : in out Client_Session;
-                           R :        Request)
+   procedure Enqueue (C : in out Client_Session;
+                      R :        Request)
    is
-      procedure C_Enqueue_Read (T   : System.Address;
-                                Req : System.Address) with
+      procedure C_Enqueue (T   : System.Address;
+                           Req : System.Address) with
          Import,
          Convention    => C,
-         External_Name => "block_client_enqueue_read";
+         External_Name => "block_client_enqueue";
       Req : Standard.C.Block.Request := Convert_Request (R);
    begin
-      C_Enqueue_Read (C.Instance, Req'Address);
-   end Enqueue_Read;
-
-   -------------------
-   -- Enqueue_Write --
-   -------------------
-
-   procedure Enqueue_Write (C : in out Client_Session;
-                            R :        Request;
-                            B :        Buffer)
-   is
-      procedure C_Enqueue_Write (T   : System.Address;
-                                 Req : System.Address;
-                                 Buf : System.Address) with
-         Import,
-         Convention    => C,
-         External_Name => "block_client_enqueue_write";
-      Req : Standard.C.Block.Request := Convert_Request (R);
-   begin
-      C_Enqueue_Write (C.Instance, Req'Address, B'Address);
-   end Enqueue_Write;
-
-   ------------------
-   -- Enqueue_Sync --
-   ------------------
-
-   procedure Enqueue_Sync (C : in out Client_Session;
-                           R :        Request)
-   is
-      procedure C_Enqueue_Sync (T : System.Address; Req : System.Address) with
-         Import,
-         Convention    => C,
-         External_Name => "block_client_enqueue_sync";
-      Req : Standard.C.Block.Request := Convert_Request (R);
-   begin
-      C_Enqueue_Sync (C.Instance, Req'Address);
-   end Enqueue_Sync;
-
-   ------------------
-   -- Enqueue_Trim --
-   ------------------
-
-   procedure Enqueue_Trim (C : in out Client_Session;
-                           R :        Request)
-   is
-      procedure C_Enqueue_Trim (T :   System.Address;
-                                Req : System.Address) with
-         Import,
-         Convention    => C,
-         External_Name => "block_client_enqueue_trim";
-      Req : Standard.C.Block.Request := Convert_Request (R);
-   begin
-      C_Enqueue_Trim (C.Instance, Req'Address);
-   end Enqueue_Trim;
+      C_Enqueue (C.Instance, Req'Address);
+   end Enqueue;
 
    ------------
    -- Submit --

--- a/platform/posix/cai-block-client.adb
+++ b/platform/posix/cai-block-client.adb
@@ -48,23 +48,32 @@ is
    -- Initialize --
    ----------------
 
-   procedure C_Write (C : Client_Instance;
-                      B : Size;
-                      S : Id;
-                      L : Count;
-                      D : System.Address);
+   procedure Crw (C : Client_Instance;
+                  K : Standard.C.Block.Request_Kind;
+                  B : Size;
+                  S : Id;
+                  L : Count;
+                  D : System.Address);
 
-   procedure C_Write (C : Client_Instance;
-                      B : Size;
-                      S : Id;
-                      L : Count;
-                      D : System.Address)
+   procedure Crw (C : Client_Instance;
+                  K : Standard.C.Block.Request_Kind;
+                  B : Size;
+                  S : Id;
+                  L : Count;
+                  D : System.Address)
    is
       Data : Buffer (1 .. B * L) with
          Address => D;
    begin
-      Write (C, B, S, L, Data);
-   end C_Write;
+      case K is
+         when Standard.C.Block.Read =>
+            Read (C, B, S, L, Data);
+         when Standard.C.Block.Write =>
+            Write (C, B, S, L, Data);
+         when others =>
+            null;
+      end case;
+   end Crw;
 
    procedure Initialize (C           : in out Client_Session;
                          Cap         :        Cai.Types.Capability;
@@ -82,7 +91,7 @@ is
          Convention    => C,
          External_Name => "block_client_initialize";
    begin
-      C_Initialize (C.Instance, C_Path'Address, Buffer_Size, Event'Address, C_Write'Address);
+      C_Initialize (C.Instance, C_Path'Address, Buffer_Size, Event'Address, Crw'Address);
    end Initialize;
 
    --------------
@@ -187,18 +196,16 @@ is
    ----------
 
    procedure Read (C : in out Client_Session;
-                   R :        Request;
-                   B :    out Buffer)
+                   R :        Request)
    is
       procedure C_Read (T   :     System.Address;
-                        Req :     System.Address;
-                        Buf : out Buffer) with
+                        Req :     System.Address) with
          Import,
          Convention    => C,
          External_Name => "block_client_read";
       Req : Standard.C.Block.Request := Convert_Request (R);
    begin
-      C_Read (C.Instance, Req'Address, B);
+      C_Read (C.Instance, Req'Address);
    end Read;
 
    -------------

--- a/src/cai-block-client.ads
+++ b/src/cai-block-client.ads
@@ -6,6 +6,19 @@ pragma Warnings (Off, "procedure ""Event"" is not referenced");
 
 generic
    with procedure Event;
+   --  Called when a read has been triggered and data is available
+   --  Pre => Data'Length = Bsize * Length
+   --
+   --  C       Client session instance identifier
+   --  Bsize   Block size of C
+   --  Start   Start block that has been read from
+   --  Length  number of blocks to read
+   --  Data    Read data
+   with procedure Read (C      : Client_Instance;
+                        Bsize  : Size;
+                        Start  : Id;
+                        Length : Count;
+                        Data   : Buffer);
    --  Write procedure called when the platform required data to write
    --  Pre => Data'Length = Bsize * Length
    --
@@ -94,13 +107,15 @@ is
                then Next'Result.Status = Ok or Next'Result.Status = Error
                else True);
 
+   --  Read the returned data from a successfully acknowledged read request
+   --
+   --  @param C  Client session instance
+   --  @param R  Request to read data from
    procedure Read (C : in out Client_Session;
-                   R :        Request;
-                   B : out    Buffer) with
+                   R :        Request) with
       Pre  => Initialized (C)
               and then R.Kind = Read
-              and then R.Status = Ok
-              and then B'Length >= R.Length * Block_Size (C),
+              and then R.Status = Ok,
       Post => Initialized (C)
               and Writable (C)'Old              = Writable (C)
               and Block_Count (C)'Old           = Block_Count (C)

--- a/src/cai-block-client.ads
+++ b/src/cai-block-client.ads
@@ -46,16 +46,16 @@ is
       Pre => Initialized (C);
 
    function Supported (C : Client_Session;
-                       R : Request) return Boolean with
-      Pre => Initialized (C);
+                       R : Request_Kind) return Boolean with
+      Pre => Initialized (C) and then Supported (C, R);
 
    procedure Enqueue_Read (C : in out Client_Session;
                            R :        Request) with
       Pre  => Initialized (C)
               and then R.Kind = Read
               and then R.Status = Raw
-              and then Ready (C, R)
-              and then Supported (C, R),
+              and then Supported (C, R.Kind)
+              and then Ready (C, R),
       Post => Initialized (C)
               and Writable (C)'Old              = Writable (C)
               and Block_Count (C)'Old           = Block_Count (C)
@@ -69,8 +69,8 @@ is
               and then R.Kind = Write
               and then R.Status = Raw
               and then B'Length = R.Length * Block_Size (C)
-              and then Ready (C, R)
-              and then Supported (C, R),
+              and then Supported (C, R.Kind)
+              and then Ready (C, R),
       Post => Initialized (C)
               and Writable (C)'Old              = Writable (C)
               and Block_Count (C)'Old           = Block_Count (C)
@@ -82,8 +82,8 @@ is
       Pre  => Initialized (C)
               and then R.Kind = Sync
               and then R.Status = Raw
-              and then Ready (C, R)
-              and then Supported (C, R),
+              and then Supported (C, R.Kind)
+              and then Ready (C, R),
       Post => Initialized (C)
               and Writable (C)'Old              = Writable (C)
               and Block_Count (C)'Old           = Block_Count (C)
@@ -95,8 +95,8 @@ is
       Pre  => Initialized (C)
               and then R.Kind = Trim
               and then R.Status = Raw
-              and then Ready (C, R)
-              and then Supported (C, R),
+              and then Supported (C, R.Kind)
+              and then Ready (C, R),
       Post => Initialized (C)
               and Writable (C)'Old              = Writable (C)
               and Block_Count (C)'Old           = Block_Count (C)

--- a/src/cai-block-client.ads
+++ b/src/cai-block-client.ads
@@ -6,6 +6,19 @@ pragma Warnings (Off, "procedure ""Event"" is not referenced");
 
 generic
    with procedure Event;
+   --  Write procedure called when the platform required data to write
+   --  Pre => Data'Length = Bsize * Length
+   --
+   --  C       Client session instance identifier
+   --  Bsize   Block size of C
+   --  Start   Start block that is written to
+   --  Length  number of blocks that will be written
+   --  Data    Data that will be written
+   with procedure Write (C      :     Client_Instance;
+                         Bsize  :     Size;
+                         Start  :     Id;
+                         Length :     Count;
+                         Data   : out Buffer);
 package Cai.Block.Client with
    SPARK_Mode
 is
@@ -49,51 +62,14 @@ is
                        R : Request_Kind) return Boolean with
       Pre => Initialized (C) and then Supported (C, R);
 
-   procedure Enqueue_Read (C : in out Client_Session;
+   --  Enqueue request
+   --
+   --  @param C  Client session instance
+   --  @param R  Request to enqueue
+   procedure Enqueue (C : in out Client_Session;
                            R :        Request) with
       Pre  => Initialized (C)
-              and then R.Kind = Read
-              and then R.Status = Raw
-              and then Supported (C, R.Kind)
-              and then Ready (C, R),
-      Post => Initialized (C)
-              and Writable (C)'Old              = Writable (C)
-              and Block_Count (C)'Old           = Block_Count (C)
-              and Block_Size (C)'Old            = Block_Size (C)
-              and Maximal_Transfer_Size (C)'Old = Maximal_Transfer_Size (C);
-
-   procedure Enqueue_Write (C : in out Client_Session;
-                            R :        Request;
-                            B :        Buffer) with
-      Pre  => Initialized (C)
-              and then R.Kind = Write
-              and then R.Status = Raw
-              and then B'Length = R.Length * Block_Size (C)
-              and then Supported (C, R.Kind)
-              and then Ready (C, R),
-      Post => Initialized (C)
-              and Writable (C)'Old              = Writable (C)
-              and Block_Count (C)'Old           = Block_Count (C)
-              and Block_Size (C)'Old            = Block_Size (C)
-              and Maximal_Transfer_Size (C)'Old = Maximal_Transfer_Size (C);
-
-   procedure Enqueue_Sync (C : in out Client_Session;
-                           R :        Request) with
-      Pre  => Initialized (C)
-              and then R.Kind = Sync
-              and then R.Status = Raw
-              and then Supported (C, R.Kind)
-              and then Ready (C, R),
-      Post => Initialized (C)
-              and Writable (C)'Old              = Writable (C)
-              and Block_Count (C)'Old           = Block_Count (C)
-              and Block_Size (C)'Old            = Block_Size (C)
-              and Maximal_Transfer_Size (C)'Old = Maximal_Transfer_Size (C);
-
-   procedure Enqueue_Trim (C : in out Client_Session;
-                           R :        Request) with
-      Pre  => Initialized (C)
-              and then R.Kind = Trim
+              and then R.Kind in Read .. Trim
               and then R.Status = Raw
               and then Supported (C, R.Kind)
               and then Ready (C, R),

--- a/test/block_client/ada_block_test.adb
+++ b/test/block_client/ada_block_test.adb
@@ -85,7 +85,7 @@ is
                   Buf (1 .. Req.Length * Block_Size) :=
                     (others => Character'Val (33 + Integer (Req.Start) mod 93));
                   exit when not Block_Client.Ready (Client, Req)
-                            or not Block_Client.Supported (Client, Req)
+                            or not Block_Client.Supported (Client, Req.Kind)
                             or S.Sent >= Request_Count
                             or S.Sent = Integer'Last;
                   Block_Client.Enqueue_Write (Client, Req, Buf (1 .. Req.Length * Block_Size));
@@ -161,7 +161,7 @@ is
                pragma Loop_Invariant (S.Sent < Integer'Last);
                Req.Start := Block.Id (S.Sent + 1);
                exit when not Block_Client.Ready (Client, Req)
-                         or not Block_Client.Supported (Client, Req)
+                         or not Block_Client.Supported (Client, Req.Kind)
                          or S.Sent >= Request_Count;
                Block_Client.Enqueue_Read (Client, Req);
                S.Sent := S.Sent + 1;

--- a/test/block_proxy/component.ads
+++ b/test/block_proxy/component.ads
@@ -26,7 +26,19 @@ package Component is
    function Writable (S : Block.Server_Instance) return Boolean;
    function Maximal_Transfer_Size (S : Block.Server_Instance) return Block.Byte_Length;
 
-   package Block_Client is new Block.Client (Event);
+   procedure Write (C :     Block.Client_Instance;
+                    B :     Block.Size;
+                    S :     Block.Id;
+                    L :     Block.Count;
+                    D : out Buffer);
+
+   procedure Read (C : Block.Client_Instance;
+                   B : Block.Size;
+                   S : Block.Id;
+                   L : Block.Count;
+                   D : Buffer);
+
+   package Block_Client is new Block.Client (Event, Read, Write);
    package Block_Server is new Block.Server (Event,
                                              Block_Count,
                                              Block_Size,


### PR DESCRIPTION
The client interface now requires callbacks for reads and writes that are called once the data is required/available. The write procedure will be called in the execution of enqueueing a write request while read will be called when calling the triggering read procedure which now doesn't take a buffer anymore. Since enqueueing a write request now also doesn't require a buffer there is only a single enqueue procedure now that takes all requests.