### PR TITLE
Block server interface refinement

### DIFF
--- a/platform/genode/block_server.cc
+++ b/platform/genode/block_server.cc
@@ -65,10 +65,7 @@ Cai::Block::Block_root::Block_root(Genode::Env &env, Cai::Block::Server &server,
 
 void Cai::Block::Block_root::handler()
 {
-    if(_server._callback){
-        Call(_server._callback);
-    }
-    _session.wakeup_client();
+    Call(_server._callback);
 }
 
 Genode::Capability<Genode::Session> Cai::Block::Block_root::cap()
@@ -188,4 +185,9 @@ void Cai::Block::Server::acknowledge(Cai::Block::Request &req)
             acked = true;
         }
     });
+}
+
+void Cai::Block::Server::unblock_client()
+{
+    blk(_session).wakeup_client();
 }

--- a/platform/genode/block_server.h
+++ b/platform/genode/block_server.h
@@ -43,6 +43,7 @@ namespace Block
             void write(Request request, void *buffer);
             void acknowledge(Request &request);
             bool initialized();
+            void unblock_client();
     };
 }
 

--- a/platform/genode/cai-block-dispatcher.adb
+++ b/platform/genode/cai-block-dispatcher.adb
@@ -77,7 +77,7 @@ is
                              L :        String)
    is
    begin
-      Serv.Initialize (Serv.Get_Instance (I), L);
+      Serv.Initialize (Serv.Get_Instance (I), L, Byte_Length(Cxx.Block.Dispatcher.Session_Size (D.Instance)));
       Cxx.Block.Server.Initialize (I.Instance,
                                    Cxx.Block.Dispatcher.Get_Capability (D.Instance),
                                    Cxx.Block.Dispatcher.Session_Size (D.Instance),

--- a/platform/genode/cai-block-dispatcher.adb
+++ b/platform/genode/cai-block-dispatcher.adb
@@ -77,7 +77,7 @@ is
                              L :        String)
    is
    begin
-      Serv.Initialize (Serv.Get_Instance (I), L, Byte_Length(Cxx.Block.Dispatcher.Session_Size (D.Instance)));
+      Serv.Initialize (Serv.Get_Instance (I), L, Byte_Length (Cxx.Block.Dispatcher.Session_Size (D.Instance)));
       Cxx.Block.Server.Initialize (I.Instance,
                                    Cxx.Block.Dispatcher.Get_Capability (D.Instance),
                                    Cxx.Block.Dispatcher.Session_Size (D.Instance),

--- a/platform/genode/cai-block-server.adb
+++ b/platform/genode/cai-block-server.adb
@@ -122,4 +122,10 @@ is
       return Cxx.Block.Server.Initialized (S.Instance) = Cxx.Bool'Val (1);
    end Initialized;
 
+   procedure Unblock_Client (S : in out Server_Session)
+   is
+   begin
+      Cxx.Block.Server.Unblock_Client (S.Instance);
+   end Unblock_Client;
+
 end Cai.Block.Server;

--- a/platform/genode/cxx-block-server.ads
+++ b/platform/genode/cxx-block-server.ads
@@ -90,7 +90,7 @@ is
       Convention    => CPP,
       External_Name => "_ZN3Cai5Block6Server11initializedEv";
 
-   procedure Unblock_Client(This : Class) with
+   procedure Unblock_Client (This : Class) with
       Global        => null,
       Import,
       Convention    => CPP,

--- a/platform/genode/cxx-block-server.ads
+++ b/platform/genode/cxx-block-server.ads
@@ -90,4 +90,10 @@ is
       Convention    => CPP,
       External_Name => "_ZN3Cai5Block6Server11initializedEv";
 
+   procedure Unblock_Client(This : Class) with
+      Global        => null,
+      Import,
+      Convention    => CPP,
+      External_Name => "_ZN3Cai5Block6Server14unblock_clientEv";
+
 end Cxx.Block.Server;

--- a/platform/posix/cai-block-dispatcher.adb
+++ b/platform/posix/cai-block-dispatcher.adb
@@ -12,7 +12,7 @@ package body Cai.Block.Dispatcher is
    begin
       --  Generated stub: replace with real body!
       pragma Compile_Time_Warning (Standard.True, "Create unimplemented");
-      return raise Program_Error with "Unimplemented function Create";
+      return raise Program_Error;
    end Create;
 
    -----------------

--- a/platform/posix/cai-block-server.adb
+++ b/platform/posix/cai-block-server.adb
@@ -104,4 +104,15 @@ package body Cai.Block.Server is
       raise Program_Error;
    end Acknowledge;
 
+   --------------------
+   -- Unblock_Client --
+   --------------------
+
+   procedure Unblock_Client (S : in out Server_Session)
+   is
+   begin
+      pragma Compile_Time_Warning (Standard.True, "Unblock_Client unimplemented");
+      raise Program_Error;
+   end Unblock_Client;
+
 end Cai.Block.Server;

--- a/platform/posix/cai-block-server.adb
+++ b/platform/posix/cai-block-server.adb
@@ -12,7 +12,7 @@ package body Cai.Block.Server is
    begin
       --  Generated stub: replace with real body!
       pragma Compile_Time_Warning (Standard.True, "Create unimplemented");
-      return raise Program_Error with "Unimplemented function Create";
+      return raise Program_Error;
    end Create;
 
    -----------------

--- a/src/cai-block-server.ads
+++ b/src/cai-block-server.ads
@@ -15,7 +15,8 @@ generic
    with function Writable (S : Server_Instance) return Boolean;
    with function Maximal_Transfer_Size (S : Server_Instance) return Byte_Length;
    with procedure Initialize (S : Server_Instance;
-                              L : String);
+                              L : String;
+                              B : Byte_Length);
    with procedure Finalize (S : Server_Instance);
 package Cai.Block.Server with
    SPARK_Mode

--- a/src/cai-block-server.ads
+++ b/src/cai-block-server.ads
@@ -73,4 +73,6 @@ is
       Pre  => Initialized (S),
       Post => Initialized (S);
 
+   procedure Unblock_Client (S : in out Server_Session);
+
 end Cai.Block.Server;

--- a/test/block_proxy/component.adb
+++ b/test/block_proxy/component.adb
@@ -7,7 +7,6 @@ package body Component is
    use all type Block_Server.Request;
    use all type Block.Id;
    use all type Block.Request_Kind;
-   use all type Block.Request_Status;
 
    Client : Block.Client_Session;
    Dispatcher : Block.Dispatcher_Session;
@@ -141,12 +140,12 @@ package body Component is
       Block_Dispatcher.Session_Cleanup (Dispatcher, Server);
    end Dispatch;
 
-   procedure Initialize_Server (S : Block.Server_Instance; L : String)
+   procedure Initialize_Server (S : Block.Server_Instance; L : String; B : Block.Byte_Length)
    is
       pragma Unreferenced (S);
    begin
       if not Block_Client.Initialized (Client) then
-         Block_Client.Initialize (Client, Capability, L);
+         Block_Client.Initialize (Client, Capability, L, B);
       end if;
    end Initialize_Server;
 

--- a/test/block_proxy/component.ads
+++ b/test/block_proxy/component.ads
@@ -19,7 +19,7 @@ package Component is
 
    procedure Event;
    procedure Dispatch;
-   procedure Initialize_Server (S : Block.Server_Instance; L : String);
+   procedure Initialize_Server (S : Block.Server_Instance; L : String; B : Block.Byte_Length);
    procedure Finalize_Server (S : Block.Server_Instance);
    function Block_Count (S : Block.Server_Instance) return Block.Count;
    function Block_Size (S : Block.Server_Instance) return Block.Size;

--- a/test/block_server/component.adb
+++ b/test/block_server/component.adb
@@ -97,6 +97,7 @@ package body Component is
             exit when R.Kind = Block.None;
          end loop;
       end if;
+      Block_Server.Unblock_Client (Server);
    end Event;
 
    function Block_Count (S : Block.Server_Instance) return Block.Count

--- a/test/block_server/component.adb
+++ b/test/block_server/component.adb
@@ -75,7 +75,6 @@ package body Component is
    is
       R : Block_Server.Request;
    begin
-      Cai.Log.Client.Info (Log, "Event");
       if Block_Server.Initialized (Server) then
          loop
             R := Block_Server.Head (Server);

--- a/test/block_server/component.adb
+++ b/test/block_server/component.adb
@@ -7,6 +7,7 @@ package body Component is
 
    Dispatcher : Block.Dispatcher_Session;
    Server : Block.Server_Session;
+   Buffer_Size : Block.Byte_Length;
 
    subtype Block_Buffer is Buffer (1 .. 512);
    type Disk is array (Block.Id range 0 .. 1023) of Block_Buffer;
@@ -123,15 +124,16 @@ package body Component is
    is
       pragma Unreferenced (S);
    begin
-      return 16#ffffffff#;
+      return Buffer_Size;
    end Maximal_Transfer_Size;
 
-   procedure Initialize (S : Block.Server_Instance; L : String)
+   procedure Initialize (S : Block.Server_Instance; L : String; B : Block.Byte_Length)
    is
       pragma Unreferenced (S);
    begin
       Cai.Log.Client.Info (Log, "Server initialize with label: " & L);
       Ram_Disk := (others => (others => 0));
+      Buffer_Size := B;
       Cai.Log.Client.Info (Log, "Initialized");
    end Initialize;
 

--- a/test/block_server/component.ads
+++ b/test/block_server/component.ads
@@ -21,7 +21,7 @@ package Component is
    function Block_Size (S : Block.Server_Instance) return Block.Size;
    function Writable (S : Block.Server_Instance) return Boolean;
    function Maximal_Transfer_Size (S : Block.Server_Instance) return Block.Byte_Length;
-   procedure Initialize (S : Block.Server_Instance; L : String);
+   procedure Initialize (S : Block.Server_Instance; L : String; B : Block.Byte_Length);
    procedure Finalize (S : Block.Server_Instance);
 
    procedure Request;


### PR DESCRIPTION
- `Initialize` now gets the requested buffer size passed
- additional procedure `Unblock_Client` that is required to tell the client to wake up again